### PR TITLE
Fix uniform-json category field

### DIFF
--- a/uniform-json/package.yaml
+++ b/uniform-json/package.yaml
@@ -6,7 +6,7 @@ github:       andrewufrank/u4blog.git/uniform-json
 maintainer:   Andrew U. Frank <frank@geoinfo.tuwien.ac.at>
 author:       Andrew Frank
 copyright:    2021 Andrew U. Frank
-category:     Data Text JSON YAML Pandoc
+category:     'Data, Text, JSON, YAML, Pandoc'
 synopsis: handling of JSON and YAML in an uniform way
 description: |
     remove particular aspects of abstraction in json and yaml - with an eye to use it with pandoc

--- a/uniform-json/uniform-json.cabal
+++ b/uniform-json/uniform-json.cabal
@@ -10,7 +10,7 @@ name:           uniform-json
 version:        0.1.5.2
 synopsis:       handling of JSON and YAML in an uniform way
 description:    remove particular aspects of abstraction in json and yaml - with an eye to use it with pandoc
-category:       Data Text JSON YAML Pandoc
+category:       Data, Text, JSON, YAML, Pandoc
 homepage:       https://github.com/andrewufrank/u4blog.git#readme
 bug-reports:    https://github.com/andrewufrank/u4blog.git/issues
 author:         Andrew Frank


### PR DESCRIPTION
Hi! I just noticed an odd category on Hackage called "Data Text JSON YAML Pandoc" - It is there because of a slight mistake in this package's metadata :)